### PR TITLE
Added support for SOCKS v5 Server

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -7,7 +7,9 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.FileNotFoundException;
 
+import java.net.Authenticator;
 import java.net.MalformedURLException;
+import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -93,6 +95,30 @@ public class App {
 
         if (cl.hasOption('w')) {
             Utils.setConfigBoolean("file.overwrite", true);
+        }
+        
+        if (cl.hasOption('s')) {
+            String sservfull = cl.getOptionValue('s').trim();
+            if (sservfull.lastIndexOf("@") != -1) {
+                int sservli = sservfull.lastIndexOf("@");
+                String userpw = sservfull.substring(0, sservli);
+                String[] usersplit = userpw.split(":");
+                String user = usersplit[0];
+                String password = usersplit[1];
+                Authenticator.setDefault(new Authenticator(){
+                    protected  PasswordAuthentication  getPasswordAuthentication(){
+                        PasswordAuthentication p = new PasswordAuthentication(user, password.toCharArray());
+                        return p;
+                    }
+                });
+                
+                sservfull = sservfull.substring(sservli + 1);
+            }
+            String[] servsplit = sservfull.split(":");
+            if (servsplit.length == 2) {
+                System.setProperty("socksProxyPort", servsplit[1]);
+            }
+            System.setProperty("socksProxyHost", servsplit[0]);
         }
 
         if (cl.hasOption('t')) {
@@ -195,6 +221,7 @@ public class App {
             String url = cl.getOptionValue('u').trim();
             ripURL(url, cl.hasOption("n"));
         }
+        
     }
 
     /**
@@ -242,6 +269,7 @@ public class App {
         opts.addOption("n", "no-prop-file", false, "Do not create properties file.");
         opts.addOption("f", "urls-file", true, "Rip URLs from a file.");
         opts.addOption("v", "version", false, "Show current version");
+        opts.addOption("s", "socks-server", true, "Use socks server ([user:password]@host[:port]");
         return opts;
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] an enhancement (See #285 but only partially)


# Description

Sorry for my horrible Java skills, but this add basic support for SOCKS v5 servers on CLI

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

